### PR TITLE
Match homeassistant core `prometheus-client` and faust-cchardet dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp==3.8.1
-prometheus-client==0.14.1
+prometheus-client>=0.7.1
 black==22.3.0
 isort==5.10.1
 cchardet==2.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ aiohttp==3.8.1
 prometheus-client>=0.7.1
 black==22.3.0
 isort==5.10.1
-cchardet==2.1.7
+faust-cchardet>=2.1.18
 aiodns==3.0.0


### PR DESCRIPTION
Currently https://github.com/meichthys/uptime_kuma which relies on pyuptimekuma is causing DependencyResolution errors when trying to install/run uptime_kuma on HomeAssistant 2023.3

It appears to be a conflict with homeassistant core which requires an older version of `prometheus-client` than what we currently require here.

Do you think this module would work with an older version, or do you know another way to resolve https://github.com/meichthys/uptime_kuma/issues/37  without relaxing our dependency requirement here? (I doubt Homeassistant will be willing to bump their dependency just for us without significant testing).